### PR TITLE
feat: implement get_trades endpoint for TASK-8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ alpaca-bars = "scripts.get_bars:main"
 alpaca-quotes = "scripts.get_quotes:main"
 alpaca-news = "scripts.get_news:main"
 alpaca-snapshot = "scripts.get_snapshot:main"
+alpaca-trades = "scripts.get_trades:main"
 alpaca-crypto = "scripts.crypto_cli:main"
 
 [tool.hatch.build.targets.wheel]

--- a/scripts/get_trades.py
+++ b/scripts/get_trades.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""CLI script to fetch historical trades."""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+
+# Import SDK modules
+try:
+    from alpaca_data import AlpacaClient
+    from alpaca_data.exceptions import (
+        AlpacaAuthError,
+        AlpacaNotFoundError,
+        AlpacaRateLimitError,
+        AlpacaAPIError,
+    )
+except ImportError as e:
+    print(f"Error importing Alpaca SDK: {e}", file=sys.stderr)
+    print("Make sure the package is installed: pip install -e .", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    """Main entry point for get_trades CLI."""
+    parser = argparse.ArgumentParser(
+        description="Fetch historical trades from Alpaca Market Data API"
+    )
+    parser.add_argument(
+        "symbols",
+        nargs="+",
+        help="Stock or crypto symbols (e.g., AAPL MSFT BTC/USD)",
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        help="Start date (YYYY-MM-DD or ISO 8601)",
+    )
+    parser.add_argument(
+        "--end",
+        type=str,
+        help="End date (YYYY-MM-DD or ISO 8601, defaults to now)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum number of trades to fetch (default: 100)",
+    )
+    parser.add_argument(
+        "--feed",
+        default="iex",
+        choices=["iex", "sip"],
+        help="Data feed (iex for free tier, sip requires subscription)",
+    )
+    parser.add_argument(
+        "--sort",
+        default="asc",
+        choices=["asc", "desc"],
+        help="Sort order (asc for ascending, desc for descending)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default="json",
+        choices=["json", "csv"],
+        help="Output format (default: json)",
+    )
+    parser.add_argument(
+        "--output-file",
+        "-f",
+        type=str,
+        help="Output file path (default: stdout)",
+    )
+
+    args = parser.parse_args()
+
+    # Load environment variables
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    # Check for API credentials
+    if not os.getenv("ALPACA_API_KEY") or not os.getenv("ALPACA_SECRET_KEY"):
+        print(
+            "Error: ALPACA_API_KEY and ALPACA_SECRET_KEY environment variables required",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        # Initialize client
+        client = AlpacaClient()
+        
+        print(f"Testing connection to Alpaca API...")
+        if not client.test_connection():
+            print("Error: Failed to connect to Alpaca API. Check your credentials.", file=sys.stderr)
+            sys.exit(1)
+            
+        print("✅ Connected successfully!")
+        
+        # Prepare parameters
+        params = {
+            'symbols': args.symbols,
+            'limit': args.limit,
+            'feed': args.feed,
+            'sort': args.sort,
+        }
+        
+        # Add optional parameters
+        if args.start:
+            params['start'] = args.start
+        if args.end:
+            params['end'] = args.end
+            
+        print(f"📊 Fetching trades for: {', '.join(args.symbols)}")
+        
+        # Make the API call
+        result = client.get_trades(**params)
+        
+        # Display results
+        print(f"✅ Retrieved {result['count']} trades")
+        
+        # Convert trades to output format
+        if args.output == "json":
+            if args.output_file:
+                import json
+                with open(args.output_file, 'w') as f:
+                    json.dump(result, f, default=str, indent=2)
+                print(f"💾 Saved to {args.output_file}")
+            else:
+                import json
+                print(json.dumps(result, default=str, indent=2))
+        
+        elif args.output == "csv":
+            if not result['trades']:
+                print("No trades to export")
+                return
+                
+            import csv
+            import io
+            
+            # Create CSV content
+            output = io.StringIO()
+            writer = csv.writer(output)
+            
+            # Write header
+            writer.writerow(['symbol', 'timestamp', 'exchange', 'price', 'size', 'conditions', 'id', 'tape'])
+            
+            # Write trade data
+            for trade in result['trades']:
+                writer.writerow([
+                    trade.symbol,
+                    trade.timestamp,
+                    trade.exchange,
+                    trade.price,
+                    trade.size,
+                    ','.join(trade.conditions or []),
+                    trade.id or '',
+                    trade.tape or ''
+                ])
+            
+            # Output CSV
+            if args.output_file:
+                with open(args.output_file, 'w') as f:
+                    f.write(output.getvalue())
+                print(f"💾 Saved to {args.output_file}")
+            else:
+                print("📄 CSV Output:")
+                print(output.getvalue())
+        
+        # Show pagination info if available
+        if result.get('has_next_page'):
+            print(f"📖 More pages available. Next page token: {result['next_page_token']}")
+        
+    except AlpacaAuthError as e:
+        print(f"Authentication Error: {e}", file=sys.stderr)
+        print("Check your API credentials in .env file", file=sys.stderr)
+        sys.exit(1)
+    except AlpacaRateLimitError as e:
+        print(f"Rate Limit Error: {e}", file=sys.stderr)
+        if e.retry_after:
+            print(f"Retry after: {e.retry_after} seconds", file=sys.stderr)
+        sys.exit(1)
+    except AlpacaNotFoundError as e:
+        print(f"Not Found Error: {e}", file=sys.stderr)
+        print("Check that your symbols are valid", file=sys.stderr)
+        sys.exit(1)
+    except AlpacaAPIError as e:
+        print(f"API Error: {e}", file=sys.stderr)
+        if e.status_code:
+            print(f"HTTP Status: {e.status_code}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/alpaca_data/client.py
+++ b/src/alpaca_data/client.py
@@ -401,3 +401,185 @@ class AlpacaClient:
             result["has_next_page"] = False
             
         return result
+
+    def get_snapshot(
+        self,
+        symbols: str | List[str],
+        feed: str = "iex",
+    ) -> Dict[str, Any]:
+        """Get latest market data snapshot for one or more symbols.
+        
+        Args:
+            symbols: Single symbol (str) or multiple symbols (list) to retrieve snapshots for
+            feed: Data feed ('iex' for free tier, 'sip' for premium)
+            
+        Returns:
+            Dictionary containing:
+                - snapshots: List of Snapshot objects
+                - symbol: The symbol(s) requested
+                - feed: The data feed used
+                - count: Number of snapshots returned
+                
+        Example:
+            >>> client = AlpacaClient()
+            >>> result = client.get_snapshot("AAPL")
+            >>> print(f"Got snapshot for {result['symbol']}: {result['snapshots'][0]}")
+            
+            >>> # Multiple symbols
+            >>> result = client.get_snapshot(["AAPL", "GOOGL"])
+            >>> for snapshot in result['snapshots']:
+            ...     print(f"{snapshot.symbol}: Latest trade {snapshot.latest_trade.price}")
+        """
+        from .models import Snapshot
+        
+        # Determine API endpoint based on single or multiple symbols
+        if isinstance(symbols, str):
+            endpoint = f"/v2/stocks/{symbols}/snapshot"
+            params = {
+                "feed": feed,
+            }
+        else:
+            endpoint = "/v2/stocks/snapshots"
+            params = {
+                "symbols": ",".join(symbols),
+                "feed": feed,
+            }
+        
+        # Make the API request
+        response = self._make_request("GET", endpoint, params=params)
+        data = response.json()
+        
+        # Parse snapshots from response
+        snapshots = []
+        
+        if isinstance(symbols, str):
+            # Single symbol response
+            snapshot_data = data.get("snapshot", {})
+            if snapshot_data:
+                snapshots.append(Snapshot.from_dict(symbols, snapshot_data))
+        else:
+            # Multi-symbol response
+            snapshots_data = data.get("snapshots", [])
+            for snapshot_data in snapshots_data:
+                symbol = snapshot_data.get("S", snapshot_data.get("symbol", "UNKNOWN"))
+                # Remove symbol field from data for Snapshot.from_dict
+                snapshot_data_copy = snapshot_data.copy()
+                snapshot_data_copy.pop("S", None)
+                snapshot_data_copy.pop("symbol", None)
+                snapshots.append(Snapshot.from_dict(symbol, snapshot_data_copy))
+        
+        # Build response with metadata
+        result = {
+            "snapshots": snapshots,
+            "symbol": symbols,
+            "feed": feed,
+            "count": len(snapshots),
+        }
+            
+        return result
+
+    def get_trades(
+        self,
+        symbols: str | List[str],
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+        limit: int = 1000,
+        feed: str = "iex",
+        sort: str = "asc",
+        page_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get historical trades for one or more symbols.
+        
+        Args:
+            symbols: Single symbol (str) or multiple symbols (list) to retrieve trades for
+            start: Start date/time in ISO format (e.g., "2024-01-01T09:30:00-05:00")
+            end: End date/time in ISO format
+            limit: Maximum number of trades to return (max 1000, default 1000)
+            feed: Data feed ('iex' for free tier, 'sip' for premium)
+            sort: Sort order ('asc' for ascending, 'desc' for descending)
+            page_token: Pagination token for next page (if provided, other params ignored except symbols)
+            
+        Returns:
+            Dictionary containing:
+                - trades: List of Trade objects
+                - symbol: The symbol(s) requested
+                - feed: The data feed used
+                - next_page_token: Token for next page (None if no more pages)
+                - count: Number of trades returned
+                
+        Example:
+            >>> client = AlpacaClient()
+            >>> result = client.get_trades("AAPL", limit=100)
+            >>> print(f"Got {len(result['trades'])} trades for {result['symbol']}")
+            
+            >>> # With date range
+            >>> result = client.get_trades("AAPL", start="2024-01-01T09:30:00-05:00", end="2024-01-01T16:00:00-05:00")
+            >>> for trade in result['trades']:
+            ...     print(f"Trade: {trade.timestamp} {trade.price} @ {trade.size}")
+        """
+        from .models import Trade
+        
+        # Determine API endpoint based on single or multiple symbols
+        if isinstance(symbols, str):
+            endpoint = f"/v2/stocks/{symbols}/trades"
+            params = {
+                "limit": limit,
+                "feed": feed,
+                "sort": sort,
+            }
+        else:
+            endpoint = "/v2/stocks/trades"
+            params = {
+                "symbols": ",".join(symbols),
+                "limit": limit,
+                "feed": feed,
+                "sort": sort,
+            }
+        
+        # Add date range parameters if provided
+        if start:
+            params["start"] = start
+        if end:
+            params["end"] = end
+        if page_token:
+            params["page_token"] = page_token
+        
+        # Make the API request
+        response = self._make_request("GET", endpoint, params=params)
+        data = response.json()
+        
+        # Parse trades from response
+        trades = []
+        trades_data = data.get("trades", [])
+        
+        if isinstance(symbols, str):
+            # Single symbol response
+            for trade_data in trades_data:
+                trades.append(Trade.from_dict(symbols, trade_data))
+        else:
+            # Multi-symbol response - each trade includes symbol field
+            for trade_data in trades_data:
+                symbol = trade_data.get("S", trade_data.get("symbol", "UNKNOWN"))
+                # Remove symbol field from data for Trade.from_dict
+                trade_data_copy = trade_data.copy()
+                trade_data_copy.pop("S", None)
+                trade_data_copy.pop("symbol", None)
+                trades.append(Trade.from_dict(symbol, trade_data_copy))
+        
+        # Build response with metadata
+        result = {
+            "trades": trades,
+            "symbol": symbols,
+            "feed": feed,
+            "next_page_token": data.get("next_page_token"),
+            "count": len(trades),
+        }
+        
+        # Add pagination info if present
+        if data.get("next_page_token"):
+            result["has_next_page"] = True
+            result["next_page_token"] = data["next_page_token"]
+        else:
+            result["has_next_page"] = False
+            
+        return result

--- a/src/alpaca_data/models.py
+++ b/src/alpaca_data/models.py
@@ -116,6 +116,20 @@ class Trade:
     id: Optional[str] = None
     tape: Optional[str] = None
 
+    @classmethod
+    def from_dict(cls, symbol: str, data: Dict[str, Any]) -> "Trade":
+        """Create Trade from API response dictionary."""
+        return cls(
+            symbol=symbol,
+            timestamp=datetime.fromisoformat(data["t"].replace("Z", "+00:00")),
+            exchange=data["x"],
+            price=data["p"],
+            size=data["s"],
+            conditions=data.get("c"),
+            id=data.get("i"),
+            tape=data.get("z"),
+        )
+
 
 @dataclass
 class Snapshot:

--- a/tests/test_get_trades.py
+++ b/tests/test_get_trades.py
@@ -1,0 +1,220 @@
+"""Test get_trades method implementation."""
+
+import pytest
+from unittest.mock import Mock, patch
+from alpaca_data import AlpacaClient, Trade
+from alpaca_data.exceptions import AlpacaAPIError
+
+
+class TestGetTrades:
+    """Test cases for the get_trades method."""
+
+    @patch('alpaca_data.client.requests.request')
+    def test_get_trades_single_symbol(self, mock_request):
+        """Test get_trades with a single symbol."""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "trades": [
+                {
+                    "t": "2024-01-01T14:30:00Z",
+                    "x": "XNAS",
+                    "p": 150.25,
+                    "s": 100,
+                    "c": ["A"],
+                    "i": "12345",
+                    "z": "B"
+                }
+            ],
+            "next_page_token": None
+        }
+        mock_request.return_value = mock_response
+
+        # Create client
+        client = AlpacaClient(api_key="test_key", secret_key="test_secret")
+
+        # Call get_trades
+        result = client.get_trades("AAPL", limit=10)
+
+        # Verify results
+        assert result["count"] == 1
+        assert result["symbol"] == "AAPL"
+        assert len(result["trades"]) == 1
+        
+        trade = result["trades"][0]
+        assert isinstance(trade, Trade)
+        assert trade.symbol == "AAPL"
+        assert trade.exchange == "XNAS"
+        assert trade.price == 150.25
+        assert trade.size == 100
+        assert trade.conditions == ["A"]
+        assert trade.id == "12345"
+        assert trade.tape == "B"
+        
+        # Verify API call
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        assert "stocks/AAPL/trades" in call_args[1]["url"]
+
+    @patch('alpaca_data.client.requests.request')
+    def test_get_trades_multiple_symbols(self, mock_request):
+        """Test get_trades with multiple symbols."""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "trades": [
+                {
+                    "t": "2024-01-01T14:30:00Z",
+                    "x": "XNAS",
+                    "p": 150.25,
+                    "s": 100,
+                    "S": "AAPL"
+                },
+                {
+                    "t": "2024-01-01T14:31:00Z",
+                    "x": "XNAS",
+                    "p": 2500.50,
+                    "s": 50,
+                    "S": "GOOGL"
+                }
+            ],
+            "next_page_token": None
+        }
+        mock_request.return_value = mock_response
+
+        # Create client
+        client = AlpacaClient(api_key="test_key", secret_key="test_secret")
+
+        # Call get_trades with multiple symbols
+        result = client.get_trades(["AAPL", "GOOGL"], limit=10)
+
+        # Verify results
+        assert result["count"] == 2
+        assert result["symbol"] == ["AAPL", "GOOGL"]
+        assert len(result["trades"]) == 2
+        
+        # Verify first trade
+        trade1 = result["trades"][0]
+        assert trade1.symbol == "AAPL"
+        assert trade1.price == 150.25
+        
+        # Verify second trade
+        trade2 = result["trades"][1]
+        assert trade2.symbol == "GOOGL"
+        assert trade2.price == 2500.50
+        
+        # Verify API call
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
+        assert "stocks/trades" in call_args[1]["url"]
+
+    @patch('alpaca_data.client.requests.request')
+    def test_get_trades_with_date_range(self, mock_request):
+        """Test get_trades with date range parameters."""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "trades": [],
+            "next_page_token": None
+        }
+        mock_request.return_value = mock_response
+
+        # Create client
+        client = AlpacaClient(api_key="test_key", secret_key="test_secret")
+
+        # Call get_trades with date range
+        result = client.get_trades(
+            "AAPL",
+            start="2024-01-01T09:30:00-05:00",
+            end="2024-01-01T16:00:00-05:00",
+            limit=50,
+            feed="sip",
+            sort="desc"
+        )
+
+        # Verify result structure
+        assert result["count"] == 0
+        assert result["symbol"] == "AAPL"
+        assert result["feed"] == "sip"
+        
+        # Verify API call parameters
+        call_args = mock_request.call_args
+        params = call_args[1]["params"]
+        assert params["start"] == "2024-01-01T09:30:00-05:00"
+        assert params["end"] == "2024-01-01T16:00:00-05:00"
+        assert params["limit"] == 50
+        assert params["feed"] == "sip"
+        assert params["sort"] == "desc"
+
+    @patch('alpaca_data.client.requests.request')
+    def test_get_trades_pagination(self, mock_request):
+        """Test get_trades with pagination."""
+        # Mock response with next page token
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "trades": [
+                {
+                    "t": "2024-01-01T14:30:00Z",
+                    "x": "XNAS",
+                    "p": 150.25,
+                    "s": 100
+                }
+            ],
+            "next_page_token": "next_page_123"
+        }
+        mock_request.return_value = mock_response
+
+        # Create client
+        client = AlpacaClient(api_key="test_key", secret_key="test_secret")
+
+        # Call get_trades
+        result = client.get_trades("AAPL")
+
+        # Verify pagination info
+        assert result["has_next_page"] is True
+        assert result["next_page_token"] == "next_page_123"
+
+    def test_trade_from_dict(self):
+        """Test Trade.from_dict method."""
+        trade_data = {
+            "t": "2024-01-01T14:30:00Z",
+            "x": "XNAS",
+            "p": 150.25,
+            "s": 100,
+            "c": ["A", "B"],
+            "i": "12345",
+            "z": "C"
+        }
+        
+        trade = Trade.from_dict("AAPL", trade_data)
+        
+        assert trade.symbol == "AAPL"
+        assert trade.exchange == "XNAS"
+        assert trade.price == 150.25
+        assert trade.size == 100
+        assert trade.conditions == ["A", "B"]
+        assert trade.id == "12345"
+        assert trade.tape == "C"
+
+    def test_trade_from_dict_minimal(self):
+        """Test Trade.from_dict with minimal data."""
+        trade_data = {
+            "t": "2024-01-01T14:30:00Z",
+            "x": "XNAS",
+            "p": 150.25,
+            "s": 100
+        }
+        
+        trade = Trade.from_dict("AAPL", trade_data)
+        
+        assert trade.symbol == "AAPL"
+        assert trade.exchange == "XNAS"
+        assert trade.price == 150.25
+        assert trade.size == 100
+        assert trade.conditions is None
+        assert trade.id is None
+        assert trade.tape is None


### PR DESCRIPTION
Implement TASK-8: Get Trades endpoint with support for single/multiple symbols, date ranges, pagination, and comprehensive testing.