### PR TITLE
feat: implement TASK-16 output formatters for all endpoints

### DIFF
--- a/src/alpaca_data/__init__.py
+++ b/src/alpaca_data/__init__.py
@@ -23,6 +23,16 @@ from .exceptions import (
     AlpacaValidationError,
 )
 from .models import Bar, Quote, Trade, Snapshot, News
+from .formatters import (
+    OutputFormatter,
+    JSONFormatter,
+    CSVFormatter,
+    DataFrameFormatter,
+    format_output,
+    to_json,
+    to_csv,
+    to_dataframe,
+)
 
 __all__ = [
     "AlpacaClient",
@@ -38,4 +48,12 @@ __all__ = [
     "Trade",
     "Snapshot",
     "News",
+    "OutputFormatter",
+    "JSONFormatter",
+    "CSVFormatter",
+    "DataFrameFormatter",
+    "format_output",
+    "to_json",
+    "to_csv",
+    "to_dataframe",
 ]

--- a/src/alpaca_data/client.py
+++ b/src/alpaca_data/client.py
@@ -3,7 +3,7 @@
 import os
 import requests
 import time
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Union
 from .rate_limiter import RateLimiter
 from .exceptions import (
     AlpacaAPIError,
@@ -12,6 +12,8 @@ from .exceptions import (
     AlpacaValidationError,
     AlpacaRateLimitError
 )
+from .formatters import OutputFormatter
+from .formatters import OutputFormatter
 
 
 class AlpacaClient:
@@ -198,7 +200,8 @@ class AlpacaClient:
         adjustment: str = "all",
         sort: str = "asc",
         page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get historical OHLCV bars for one or more symbols.
         
         Args:
@@ -295,8 +298,13 @@ class AlpacaClient:
             result["next_page_token"] = data["next_page_token"]
         else:
             result["has_next_page"] = False
-            
-        return result
+        
+        # Apply output formatting if requested
+        if output_format.lower() != "dict":
+            formatter = OutputFormatter()
+            return formatter.format(result, output_format.lower())
+        
+        return self._apply_formatting(result, output_format)
 
     def get_quotes(
         self,
@@ -307,7 +315,8 @@ class AlpacaClient:
         feed: str = "iex",
         sort: str = "asc",
         page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get latest and historical NBBO quotes for one or more symbols.
         
         Args:
@@ -399,14 +408,16 @@ class AlpacaClient:
             result["next_page_token"] = data["next_page_token"]
         else:
             result["has_next_page"] = False
-            
-        return result
+        
+        # Apply output formatting if requested
+        return self._apply_formatting(result, output_format)
 
     def get_snapshot(
         self,
         symbols: str | List[str],
         feed: str = "iex",
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get latest market data snapshot for one or more symbols.
         
         Args:
@@ -475,7 +486,7 @@ class AlpacaClient:
             "count": len(snapshots),
         }
             
-        return result
+        return self._apply_formatting(result, output_format)
 
     def get_trades(
         self,
@@ -486,7 +497,8 @@ class AlpacaClient:
         feed: str = "iex",
         sort: str = "asc",
         page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get historical trades for one or more symbols.
         
         Args:
@@ -581,7 +593,7 @@ class AlpacaClient:
         else:
             result["has_next_page"] = False
             
-        return result
+        return self._apply_formatting(result, output_format)
 
     def get_news(
         self,
@@ -592,7 +604,8 @@ class AlpacaClient:
         include_content: bool = False,
         sort: str = "desc",
         page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get news articles for specified symbols and date range.
         
         Args:
@@ -677,7 +690,7 @@ class AlpacaClient:
         if end:
             result["end"] = end
             
-        return result
+        return self._apply_formatting(result, output_format)
 
     def get_crypto_bars(
         self,
@@ -689,7 +702,8 @@ class AlpacaClient:
         exchange: Optional[str] = None,
         sort: str = "asc",
         page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get historical OHLCV bars for crypto pairs (BTC/USD, ETH/USD, etc.).
         
         Args:
@@ -792,7 +806,7 @@ class AlpacaClient:
         else:
             result["has_next_page"] = False
             
-        return result
+        return self._apply_formatting(result, output_format)
 
     def get_crypto_quotes(
         self,
@@ -803,7 +817,8 @@ class AlpacaClient:
         exchange: Optional[str] = None,
         sort: str = "asc",
         page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get latest and historical quotes for crypto pairs (BTC/USD, ETH/USD, etc.).
         
         Args:
@@ -901,7 +916,7 @@ class AlpacaClient:
         else:
             result["has_next_page"] = False
             
-        return result
+        return self._apply_formatting(result, output_format)
 
 
     def get_crypto_trades(
@@ -913,7 +928,8 @@ class AlpacaClient:
         exchange: Optional[str] = None,
         sort: str = "asc",
         page_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get latest and historical trades for crypto pairs (BTC/USD, ETH/USD, etc.).
         
         Args:
@@ -1011,13 +1027,14 @@ class AlpacaClient:
         else:
             result["has_next_page"] = False
             
-        return result
+        return self._apply_formatting(result, output_format)
 
     def get_crypto_snapshot(
         self,
         symbol_or_symbols: str | List[str],
         exchange: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        output_format: str = "dict",
+    ) -> Union[Dict[str, Any], str]:
         """Get latest market data snapshot for crypto pairs (BTC/USD, ETH/USD, etc.).
         
         Args:
@@ -1090,4 +1107,26 @@ class AlpacaClient:
         if exchange:
             result["exchange"] = exchange
             
-        return result
+        return self._apply_formatting(result, output_format)
+
+    def _apply_formatting(
+        self, 
+        data: Dict[str, Any], 
+        output_format: str,
+        filename: Optional[str] = None
+    ) -> Union[Dict[str, Any], str]:
+        """Apply output formatting to API response data.
+        
+        Args:
+            data: API response data
+            output_format: Output format ('dict', 'json', 'csv', 'dataframe')
+            filename: Optional filename for CSV output
+            
+        Returns:
+            Formatted data (dict, string, or DataFrame)
+        """
+        if output_format.lower() == "dict":
+            return data
+        
+        formatter = OutputFormatter()
+        return formatter.format(data, output_format.lower(), filename=filename)

--- a/src/alpaca_data/formatters.py
+++ b/src/alpaca_data/formatters.py
@@ -1,0 +1,388 @@
+"""Output formatters for Alpaca Market Data SDK.
+
+This module provides formatters to convert data models into various output formats
+including JSON, CSV, and pandas DataFrames.
+"""
+
+import json
+import csv
+import io
+from typing import Any, Dict, List, Optional, Union
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import pandas as pd
+    PANDAS_AVAILABLE = True
+except ImportError:
+    PANDAS_AVAILABLE = False
+
+from .models import Bar, Quote, Trade, Snapshot, News
+
+
+class DataFormatter:
+    """Base class for data formatters."""
+    
+    def format(self, data: Any, **kwargs) -> Any:
+        """Format data to the desired output format.
+        
+        Args:
+            data: Data to format (models, lists, or API responses)
+            **kwargs: Additional formatting options
+            
+        Returns:
+            Formatted data
+        """
+        raise NotImplementedError
+
+
+class JSONFormatter(DataFormatter):
+    """Format data as JSON."""
+    
+    def format(self, data: Any, indent: int = 2, sort_keys: bool = False, **kwargs) -> str:
+        """Format data as JSON string.
+        
+        Args:
+            data: Data to format
+            indent: JSON indentation level
+            sort_keys: Whether to sort dictionary keys
+            **kwargs: Additional JSON options
+            
+        Returns:
+            JSON formatted string
+        """
+        def json_serializer(obj):
+            """Custom JSON serializer for datetime objects and models."""
+            if isinstance(obj, datetime):
+                return obj.isoformat()
+            elif hasattr(obj, 'to_dict'):
+                return obj.to_dict()
+            elif isinstance(obj, (Bar, Quote, Trade, Snapshot, News)):
+                return obj.to_dict()
+            elif isinstance(obj, (list, tuple)):
+                return [json_serializer(item) for item in obj]
+            elif isinstance(obj, dict):
+                return {k: json_serializer(v) for k, v in obj.items()}
+            else:
+                return obj
+        
+        return json.dumps(json_serializer(data), indent=indent, sort_keys=sort_keys, **kwargs)
+
+
+class CSVFormatter(DataFormatter):
+    """Format data as CSV."""
+    
+    def format(self, data: Any, filename: Optional[str] = None, **kwargs) -> str:
+        """Format data as CSV string.
+        
+        Args:
+            data: Data to format (lists of models or API responses with lists)
+            filename: Optional filename to save to (if provided, returns empty string)
+            **kwargs: Additional CSV options (delimiter, quoting, etc.)
+            
+        Returns:
+            CSV formatted string (or empty string if filename provided)
+        """
+        # Extract data items from various input formats
+        items = self._extract_items(data)
+        
+        if not items:
+            return ""
+        
+        # Get field names from first item
+        if hasattr(items[0], 'to_dict'):
+            fieldnames = list(items[0].to_dict().keys())
+        else:
+            fieldnames = list(items[0].keys())
+        
+        # Create CSV output
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=fieldnames, **kwargs)
+        writer.writeheader()
+        
+        for item in items:
+            if hasattr(item, 'to_dict'):
+                writer.writerow(item.to_dict())
+            else:
+                writer.writerow(item)
+        
+        csv_content = output.getvalue()
+        output.close()
+        
+        # Save to file if filename provided
+        if filename:
+            Path(filename).write_text(csv_content, encoding='utf-8')
+            return ""
+        
+        return csv_content
+    
+    def _extract_items(self, data: Any) -> List[Dict[str, Any]]:
+        """Extract data items from various input formats."""
+        if isinstance(data, list):
+            return data
+        elif isinstance(data, dict):
+            # Check for common list fields in API responses
+            for field in ['bars', 'quotes', 'trades', 'snapshots', 'news']:
+                if field in data and isinstance(data[field], list):
+                    return data[field]
+            # Return empty list if no list fields found
+            return []
+        else:
+            # Single item - wrap in list
+            if hasattr(data, 'to_dict'):
+                return [data.to_dict()]
+            elif isinstance(data, dict):
+                return [data]
+            else:
+                return []
+
+
+class DataFrameFormatter(DataFormatter):
+    """Format data as pandas DataFrame."""
+    
+    def __init__(self):
+        if not PANDAS_AVAILABLE:
+            raise ImportError("pandas is required for DataFrame formatting. Install with: pip install pandas")
+    
+    def format(self, data: Any, **kwargs) -> 'pd.DataFrame':
+        """Format data as pandas DataFrame.
+        
+        Args:
+            data: Data to format (lists of models or API responses with lists)
+            **kwargs: Additional pandas DataFrame options
+            
+        Returns:
+            pandas DataFrame
+        """
+        import pandas as pd
+        
+        # Extract data items from various input formats
+        items = self._extract_items(data)
+        
+        if not items:
+            return pd.DataFrame()
+        
+        # Convert to DataFrame
+        df = pd.DataFrame(items)
+        
+        # Apply additional formatting options
+        return df
+    
+    def _extract_items(self, data: Any) -> List[Dict[str, Any]]:
+        """Extract data items from various input formats."""
+        if isinstance(data, list):
+            # Check if list contains model objects
+            if data and hasattr(data[0], 'to_dict'):
+                return [item.to_dict() for item in data]
+            return data
+        elif isinstance(data, dict):
+            # Check for common list fields in API responses
+            for field in ['bars', 'quotes', 'trades', 'snapshots', 'news']:
+                if field in data and isinstance(data[field], list):
+                    items = data[field]
+                    # Convert model objects to dictionaries
+                    if items and hasattr(items[0], 'to_dict'):
+                        return [item.to_dict() for item in items]
+                    return items
+            return []
+        else:
+            # Single item
+            if hasattr(data, 'to_dict'):
+                return [data.to_dict()]
+            elif isinstance(data, dict):
+                return [data]
+            else:
+                return []
+
+
+class OutputFormatter:
+    """Main formatter class that delegates to specific formatters."""
+    
+    def __init__(self):
+        self.formatters = {
+            'json': JSONFormatter(),
+            'csv': CSVFormatter(),
+            'dataframe': DataFrameFormatter(),
+        }
+    
+    def format(
+        self, 
+        data: Any, 
+        format_type: str = 'json', 
+        filename: Optional[str] = None,
+        **kwargs
+    ) -> Union[str, Any]:
+        """Format data to the specified output format.
+        
+        Args:
+            data: Data to format
+            format_type: Output format ('json', 'csv', 'dataframe')
+            filename: Optional filename for CSV output
+            **kwargs: Additional formatting options
+            
+        Returns:
+            Formatted data (string for JSON/CSV, DataFrame for dataframe)
+            
+        Raises:
+            ValueError: If format_type is not supported
+            ImportError: If pandas is required but not available
+        """
+        format_type = format_type.lower()
+        
+        if format_type not in self.formatters:
+            raise ValueError(f"Unsupported format type: {format_type}. "
+                           f"Supported formats: {list(self.formatters.keys())}")
+        
+        formatter = self.formatters[format_type]
+        
+        # Handle filename parameter for CSV formatter
+        if format_type == 'csv':
+            return formatter.format(data, filename=filename, **kwargs)
+        else:
+            return formatter.format(data, **kwargs)
+    
+    def get_supported_formats(self) -> List[str]:
+        """Get list of supported output formats.
+        
+        Returns:
+            List of supported format names
+        """
+        return list(self.formatters.keys())
+    
+    def is_format_available(self, format_type: str) -> bool:
+        """Check if a format is available (e.g., pandas for DataFrame).
+        
+        Args:
+            format_type: Format to check
+            
+        Returns:
+            True if format is available, False otherwise
+        """
+        format_type = format_type.lower()
+        
+        if format_type not in self.formatters:
+            return False
+        
+        if format_type == 'dataframe':
+            return PANDAS_AVAILABLE
+        
+        return True
+
+
+# Utility functions for easy formatting
+def format_output(
+    data: Any, 
+    format_type: str = 'json', 
+    filename: Optional[str] = None,
+    **kwargs
+) -> Union[str, Any]:
+    """Convenience function to format data.
+    
+    Args:
+        data: Data to format
+        format_type: Output format ('json', 'csv', 'dataframe')
+        filename: Optional filename for CSV output
+        **kwargs: Additional formatting options
+        
+    Returns:
+        Formatted data
+    """
+    formatter = OutputFormatter()
+    return formatter.format(data, format_type, filename, **kwargs)
+
+
+def to_json(data: Any, **kwargs) -> str:
+    """Convert data to JSON format.
+    
+    Args:
+        data: Data to format
+        **kwargs: Additional JSON options
+        
+    Returns:
+        JSON formatted string
+    """
+    return format_output(data, 'json', **kwargs)
+
+
+def to_csv(data: Any, filename: Optional[str] = None, **kwargs) -> str:
+    """Convert data to CSV format.
+    
+    Args:
+        data: Data to format
+        filename: Optional filename to save to
+        **kwargs: Additional CSV options
+        
+    Returns:
+        CSV formatted string (or empty string if filename provided)
+    """
+    return format_output(data, 'csv', filename=filename, **kwargs)
+
+
+def to_dataframe(data: Any, **kwargs) -> 'pd.DataFrame':
+    """Convert data to pandas DataFrame format.
+    
+    Args:
+        data: Data to format
+        **kwargs: Additional DataFrame options
+        
+    Returns:
+        pandas DataFrame
+        
+    Raises:
+        ImportError: If pandas is not available
+    """
+    return format_output(data, 'dataframe', **kwargs)
+
+
+# Format detection utilities
+def detect_data_type(data: Any) -> str:
+    """Detect the type of data being formatted.
+    
+    Args:
+        data: Data to analyze
+        
+    Returns:
+        String representing the data type
+    """
+    if isinstance(data, list):
+        if data and hasattr(data[0], 'to_dict'):
+            return f"list_of_{data[0].__class__.__name__.lower()}s"
+        return "list"
+    elif isinstance(data, dict):
+        # Check for API response patterns
+        for field in ['bars', 'quotes', 'trades', 'snapshots', 'news']:
+            if field in data:
+                return f"api_response_with_{field}"
+        return "dict"
+    elif hasattr(data, 'to_dict'):
+        return data.__class__.__name__.lower()
+    else:
+        return type(data).__name__.lower()
+
+
+def suggest_format(data: Any) -> str:
+    """Suggest the best format for the given data.
+    
+    Args:
+        data: Data to analyze
+        
+    Returns:
+        Suggested format name
+    """
+    data_type = detect_data_type(data)
+    
+    # Single objects work well with JSON
+    if data_type in ['bar', 'quote', 'trade', 'snapshot', 'news']:
+        return 'json'
+    
+    # Lists work well with CSV or DataFrame
+    elif data_type.startswith('list_of_'):
+        return 'csv'
+    
+    # API responses work well with JSON
+    elif data_type.startswith('api_response_with_'):
+        return 'json'
+    
+    # Default to JSON
+    else:
+        return 'json'

--- a/tests/test_task_16.py
+++ b/tests/test_task_16.py
@@ -1,0 +1,312 @@
+"""Test for TASK-16: Output Formatters"""
+
+import unittest
+import tempfile
+import os
+from datetime import datetime
+from src.alpaca_data.formatters import (
+    JSONFormatter, 
+    CSVFormatter, 
+    DataFrameFormatter,
+    OutputFormatter,
+    format_output,
+    to_json,
+    to_csv,
+    to_dataframe,
+    detect_data_type,
+    suggest_format
+)
+from src.alpaca_data.models import Bar, Quote, Trade, Snapshot, News
+
+
+class TestFormatters(unittest.TestCase):
+    """Test cases for output formatters."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.bar = Bar(
+            symbol="AAPL",
+            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+            open=150.0,
+            high=155.0,
+            low=149.0,
+            close=153.0,
+            volume=1000000,
+            trade_count=5000
+        )
+        
+        self.quote = Quote(
+            symbol="AAPL",
+            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+            ask_exchange="XNAS",
+            ask_price=153.5,
+            ask_size=100,
+            bid_exchange="XNAS",
+            bid_price=153.0,
+            bid_size=200
+        )
+        
+        self.trade = Trade(
+            symbol="AAPL",
+            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+            exchange="XNAS",
+            price=153.0,
+            size=100
+        )
+        
+        self.bars_list = [self.bar, self.bar]
+        self.api_response = {
+            "bars": self.bars_list,
+            "symbol": "AAPL",
+            "timeframe": "1Day",
+            "count": 2
+        }
+
+    def test_json_formatter_single_model(self):
+        """Test JSON formatter with single model."""
+        formatter = JSONFormatter()
+        result = formatter.format(self.bar)
+        
+        # Should return valid JSON
+        import json
+        parsed = json.loads(result)
+        
+        self.assertEqual(parsed["symbol"], "AAPL")
+        self.assertEqual(parsed["open"], 150.0)
+        self.assertEqual(parsed["close"], 153.0)
+
+    def test_json_formatter_list(self):
+        """Test JSON formatter with list of models."""
+        formatter = JSONFormatter()
+        result = formatter.format(self.bars_list)
+        
+        import json
+        parsed = json.loads(result)
+        
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["symbol"], "AAPL")
+
+    def test_json_formatter_api_response(self):
+        """Test JSON formatter with API response."""
+        formatter = JSONFormatter()
+        result = formatter.format(self.api_response)
+        
+        import json
+        parsed = json.loads(result)
+        
+        self.assertIn("bars", parsed)
+        self.assertIn("symbol", parsed)
+        self.assertEqual(parsed["count"], 2)
+
+    def test_csv_formatter_list(self):
+        """Test CSV formatter with list of models."""
+        formatter = CSVFormatter()
+        result = formatter.format(self.bars_list)
+        
+        # Should return CSV content
+        lines = result.strip().split('\n')
+        self.assertTrue(len(lines) > 1)  # Header + data rows
+        
+        # Check header
+        headers = lines[0].split(',')
+        self.assertIn("symbol", headers)
+        self.assertIn("open", headers)
+        self.assertIn("close", headers)
+
+    def test_csv_formatter_with_filename(self):
+        """Test CSV formatter with filename."""
+        formatter = CSVFormatter()
+        
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as tmp:
+            tmp_filename = tmp.name
+        
+        try:
+            formatter.format(self.bars_list, filename=tmp_filename)
+            
+            # File should exist and have content
+            self.assertTrue(os.path.exists(tmp_filename))
+            
+            with open(tmp_filename, 'r') as f:
+                content = f.read()
+                self.assertIn("symbol", content)
+                self.assertIn("AAPL", content)
+                
+        finally:
+            if os.path.exists(tmp_filename):
+                os.unlink(tmp_filename)
+
+    def test_dataframe_formatter(self):
+        """Test DataFrame formatter."""
+        try:
+            formatter = DataFrameFormatter()
+            df = formatter.format(self.bars_list)
+            
+            # Should be a pandas DataFrame
+            import pandas as pd
+            self.assertIsInstance(df, pd.DataFrame)
+            
+            # Should have correct columns and data
+            self.assertIn("symbol", df.columns)
+            self.assertEqual(len(df), 2)
+            self.assertEqual(df["symbol"].iloc[0], "AAPL")
+            
+        except ImportError:
+            self.skipTest("pandas not available")
+
+    def test_output_formatter_interface(self):
+        """Test main OutputFormatter interface."""
+        output_formatter = OutputFormatter()
+        
+        # Test supported formats
+        supported = output_formatter.get_supported_formats()
+        self.assertIn("json", supported)
+        self.assertIn("csv", supported)
+        
+        # Test JSON output
+        json_result = output_formatter.format(self.bar, "json")
+        self.assertIsInstance(json_result, str)
+        
+        # Test CSV output
+        csv_result = output_formatter.format(self.bars_list, "csv")
+        self.assertIsInstance(csv_result, str)
+        self.assertIn("symbol", csv_result)
+
+    def test_convenience_functions(self):
+        """Test convenience functions."""
+        # Test to_json
+        json_result = to_json(self.bar)
+        self.assertIsInstance(json_result, str)
+        
+        # Test to_csv
+        csv_result = to_csv(self.bars_list)
+        self.assertIsInstance(csv_result, str)
+        self.assertIn("symbol", csv_result)
+        
+        # Test to_dataframe (if pandas available)
+        try:
+            df = to_dataframe(self.bars_list)
+            import pandas as pd
+            self.assertIsInstance(df, pd.DataFrame)
+        except ImportError:
+            self.skipTest("pandas not available")
+
+    def test_data_type_detection(self):
+        """Test data type detection."""
+        # Single model
+        detected = detect_data_type(self.bar)
+        self.assertEqual(detected, "bar")
+        
+        # List of models
+        detected = detect_data_type(self.bars_list)
+        self.assertEqual(detected, "list_of_bars")
+        
+        # API response
+        detected = detect_data_type(self.api_response)
+        self.assertEqual(detected, "api_response_with_bars")
+
+    def test_format_suggestion(self):
+        """Test format suggestion."""
+        # Single model should suggest JSON
+        suggested = suggest_format(self.bar)
+        self.assertEqual(suggested, "json")
+        
+        # List should suggest CSV
+        suggested = suggest_format(self.bars_list)
+        self.assertEqual(suggested, "csv")
+        
+        # API response should suggest JSON
+        suggested = suggest_format(self.api_response)
+        self.assertEqual(suggested, "json")
+
+    def test_error_handling(self):
+        """Test error handling."""
+        output_formatter = OutputFormatter()
+        
+        # Unsupported format
+        with self.assertRaises(ValueError):
+            output_formatter.format(self.bar, "unsupported_format")
+        
+        # DataFrame without pandas
+        # This should work since we check availability in init
+        try:
+            df_formatter = DataFrameFormatter()
+            df_formatter.format(self.bars_list)
+        except ImportError:
+            self.skipTest("pandas not available")
+
+    def test_json_with_options(self):
+        """Test JSON formatter with options."""
+        formatter = JSONFormatter()
+        
+        # Test with indent and sort_keys
+        result = formatter.format(self.bar, indent=4, sort_keys=True)
+        
+        import json
+        parsed = json.loads(result)
+        self.assertEqual(parsed["symbol"], "AAPL")
+
+    def test_csv_with_options(self):
+        """Test CSV formatter with options."""
+        formatter = CSVFormatter()
+        
+        # Test with custom delimiter
+        result = formatter.format(self.bars_list, delimiter=';')
+        
+        # Should use semicolon delimiter
+        lines = result.strip().split('\n')
+        if len(lines) > 1:
+            headers = lines[0].split(';')
+            self.assertIn("symbol", headers)
+
+    def test_empty_data_handling(self):
+        """Test handling of empty data."""
+        formatter = JSONFormatter()
+        
+        # Empty list
+        result = formatter.format([])
+        self.assertEqual(result, "[]")
+        
+        # Empty dict
+        result = formatter.format({})
+        self.assertEqual(result, "{}")
+
+    def test_nested_data_handling(self):
+        """Test handling of nested data structures."""
+        nested_data = {
+            "bar": self.bar,
+            "quote": self.quote,
+            "nested_list": [self.bar, self.quote],
+            "simple_value": "test"
+        }
+        
+        formatter = JSONFormatter()
+        result = formatter.format(nested_data)
+        
+        import json
+        parsed = json.loads(result)
+        
+        self.assertEqual(parsed["simple_value"], "test")
+        self.assertIn("nested_list", parsed)
+        self.assertEqual(len(parsed["nested_list"]), 2)
+
+    def test_quote_and_trade_formatting(self):
+        """Test formatting of Quote and Trade models."""
+        # Test Quote formatting
+        quote_formatter = JSONFormatter()
+        quote_result = quote_formatter.format(self.quote)
+        
+        import json
+        parsed_quote = json.loads(quote_result)
+        self.assertEqual(parsed_quote["symbol"], "AAPL")
+        self.assertEqual(parsed_quote["ask_price"], 153.5)
+        
+        # Test Trade formatting
+        trade_result = quote_formatter.format(self.trade)
+        parsed_trade = json.loads(trade_result)
+        self.assertEqual(parsed_trade["price"], 153.0)
+        self.assertEqual(parsed_trade["size"], 100)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_task_16_integration.py
+++ b/tests/test_task_16_integration.py
@@ -1,0 +1,246 @@
+"""Integration test for TASK-16: Client endpoints with output formatters."""
+
+import unittest
+from unittest.mock import Mock, patch
+from datetime import datetime
+from src.alpaca_data.client import AlpacaClient
+from src.alpaca_data.models import Bar, Quote, Trade
+
+
+class TestClientWithFormatters(unittest.TestCase):
+    """Test that client endpoints work with output formatters."""
+
+    def setUp(self):
+        """Set up test client with mock API."""
+        self.client = AlpacaClient(api_key="test_key", secret_key="test_secret")
+        self.mock_response = Mock()
+        self.mock_response.json.return_value = {
+            "bars": [
+                {
+                    "t": "2024-01-01T00:00:00Z",
+                    "o": 150.0,
+                    "h": 155.0,
+                    "l": 149.0,
+                    "c": 153.0,
+                    "v": 1000000,
+                    "n": 5000
+                }
+            ],
+            "symbol": "AAPL",
+            "next_page_token": None
+        }
+
+    @patch('requests.request')
+    def test_get_bars_json_format(self, mock_request):
+        """Test get_bars with JSON output format."""
+        mock_request.return_value = self.mock_response
+        
+        # Test JSON format
+        result = self.client.get_bars("AAPL", output_format="json")
+        self.assertIsInstance(result, str)
+        
+        # Should be valid JSON
+        import json
+        parsed = json.loads(result)
+        self.assertIn("bars", parsed)
+        self.assertIn("symbol", parsed)
+
+    @patch('requests.request')
+    def test_get_bars_csv_format(self, mock_request):
+        """Test get_bars with CSV output format."""
+        mock_request.return_value = self.mock_response
+        
+        # Test CSV format
+        result = self.client.get_bars("AAPL", output_format="csv")
+        self.assertIsInstance(result, str)
+        
+        # Should contain CSV content
+        self.assertIn("symbol", result)
+        self.assertIn("AAPL", result)
+
+    @patch('requests.request')
+    def test_get_bars_dataframe_format(self, mock_request):
+        """Test get_bars with DataFrame output format."""
+        mock_request.return_value = self.mock_response
+        
+        try:
+            # Test DataFrame format
+            result = self.client.get_bars("AAPL", output_format="dataframe")
+            self.assertIsNotNone(result)
+            
+            import pandas as pd
+            self.assertIsInstance(result, pd.DataFrame)
+            self.assertIn("symbol", result.columns)
+            
+        except ImportError:
+            self.skipTest("pandas not available")
+
+    @patch('requests.request')
+    def test_get_bars_dict_format(self, mock_request):
+        """Test get_bars with dict output format (default)."""
+        mock_request.return_value = self.mock_response
+        
+        # Test dict format (default)
+        result = self.client.get_bars("AAPL", output_format="dict")
+        self.assertIsInstance(result, dict)
+        self.assertIn("bars", result)
+        self.assertIn("symbol", result)
+
+    @patch('requests.request')
+    def test_get_quotes_with_format(self, mock_request):
+        """Test get_quotes with output formatting."""
+        quotes_response = Mock()
+        quotes_response.json.return_value = {
+            "quotes": [
+                {
+                    "t": "2024-01-01T00:00:00Z",
+                    "ap": 153.5,
+                    "as": 100,
+                    "bp": 153.0,
+                    "bs": 200,
+                    "ax": "XNAS",
+                    "bx": "XNAS"
+                }
+            ],
+            "symbol": "AAPL",
+            "next_page_token": None
+        }
+        mock_request.return_value = quotes_response
+        
+        # Test JSON format
+        result = self.client.get_quotes("AAPL", output_format="json")
+        self.assertIsInstance(result, str)
+        
+        import json
+        parsed = json.loads(result)
+        self.assertIn("quotes", parsed)
+
+    @patch('requests.request')
+    def test_get_trades_with_format(self, mock_request):
+        """Test get_trades with output formatting."""
+        trades_response = Mock()
+        trades_response.json.return_value = {
+            "trades": [
+                {
+                    "t": "2024-01-01T00:00:00Z",
+                    "p": 153.0,
+                    "s": 100,
+                    "x": "XNAS"
+                }
+            ],
+            "symbol": "AAPL",
+            "next_page_token": None
+        }
+        mock_request.return_value = trades_response
+        
+        # Test CSV format
+        result = self.client.get_trades("AAPL", output_format="csv")
+        self.assertIsInstance(result, str)
+        self.assertIn("symbol", result)
+
+    @patch('requests.request')
+    def test_get_news_with_format(self, mock_request):
+        """Test get_news with output formatting."""
+        news_response = Mock()
+        news_response.json.return_value = {
+            "news": [
+                {
+                    "id": "123",
+                    "headline": "Test News",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "symbols": ["AAPL"],
+                    "source": "Test Source"
+                }
+            ],
+            "next_page_token": None
+        }
+        mock_request.return_value = news_response
+        
+        # Test JSON format
+        result = self.client.get_news(output_format="json")
+        self.assertIsInstance(result, str)
+        
+        import json
+        parsed = json.loads(result)
+        self.assertIn("news", parsed)
+
+    @patch('requests.request')
+    def test_crypto_endpoints_with_format(self, mock_request):
+        """Test crypto endpoints with output formatting."""
+        crypto_response = Mock()
+        crypto_response.json.return_value = {
+            "bars": [
+                {
+                    "t": "2024-01-01T00:00:00Z",
+                    "o": 50000.0,
+                    "h": 51000.0,
+                    "l": 49000.0,
+                    "c": 50500.0,
+                    "v": 100.5
+                }
+            ],
+            "symbol": "BTC/USD",
+            "next_page_token": None
+        }
+        mock_request.return_value = crypto_response
+        
+        # Test crypto bars with JSON format
+        result = self.client.get_crypto_bars("BTC/USD", output_format="json")
+        self.assertIsInstance(result, str)
+        
+        import json
+        parsed = json.loads(result)
+        self.assertIn("bars", parsed)
+
+    def test_unsupported_format(self):
+        """Test handling of unsupported output formats."""
+        with patch('requests.request') as mock_request:
+            mock_request.return_value = self.mock_response
+            
+            # Should raise ValueError for unsupported format
+            with self.assertRaises(ValueError):
+                self.client.get_bars("AAPL", output_format="unsupported_format")
+
+    def test_formatting_helper_method(self):
+        """Test the _apply_formatting helper method."""
+        test_data = {"test": "data", "items": [1, 2, 3]}
+        
+        # Test dict format
+        result = self.client._apply_formatting(test_data, "dict")
+        self.assertEqual(result, test_data)
+        
+        # Test JSON format
+        result = self.client._apply_formatting(test_data, "json")
+        self.assertIsInstance(result, str)
+        
+        # Test CSV format - use proper API response structure with 'bars' field
+        csv_data = {"bars": [test_data], "next_page_token": None}
+        result = self.client._apply_formatting(csv_data, "csv")
+        self.assertIsInstance(result, str)
+        self.assertIn("test", result)
+
+    def test_convenience_functions_integration(self):
+        """Test that convenience functions work with models."""
+        from src.alpaca_data.formatters import to_json, to_csv
+        
+        bar = Bar(
+            symbol="AAPL",
+            timestamp=datetime.now(),
+            open=150.0,
+            high=155.0,
+            low=149.0,
+            close=153.0,
+            volume=1000000
+        )
+        
+        # Test convenience functions
+        json_result = to_json(bar)
+        self.assertIsInstance(json_result, str)
+        
+        csv_result = to_csv([bar])
+        self.assertIsInstance(csv_result, str)
+        self.assertIn("symbol", csv_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Successfully implemented TASK-16: Output Formatters for all API endpoints.

## Changes Made
- Created comprehensive formatters module with JSON, CSV, and DataFrame support
- Added output_format parameter to all 9 client endpoints (stock and crypto)
- Added convenience functions: to_json, to_csv, to_dataframe
- Updated __init__.py to export formatters
- Added extensive test coverage: 27 total tests passing

## Features
- JSON formatting with custom serializers for datetime and model objects
- CSV formatting with optional filename saving and custom delimiters
- DataFrame formatting (requires pandas) for data analysis workflows
- Backward compatibility with existing dict output format (default)

## Testing
- 16 formatter-specific tests covering all formatters and edge cases
- 11 integration tests verifying client endpoint functionality
- All 27 tests passing with 58% overall coverage

## Acceptance Criteria Met
✅ All endpoints support format parameter - 9/9 endpoints updated
✅ Multiple output formats - JSON, CSV, DataFrame implemented
✅ Convenience functions available
✅ Backward compatibility preserved
✅ Comprehensive testing completed

The output formatters provide flexible data export options while maintaining full backward compatibility.